### PR TITLE
Contextualize the blobstore API

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ dep ensure stackmachine.com/blobstore
 package main
 
 import (
+	"context"
+	"fmt"
+
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 
@@ -23,6 +26,9 @@ import (
 )
 
 func main() {
+	// Create a ctx
+	ctx := context.Background()
+
 	// Create a store backed by an S3 bucket
 	sess := session.Must(session.NewSession())
 	bucket := blobstore.NewS3(s3.New(session), "example-bucket-name")
@@ -41,5 +47,8 @@ func main() {
 
 	// Start all keys with a shared prefix
 	final := blobstore.Prefixed("prefix", store)
+
+	// Check if a key exists; outputs "false"
+	fmt.Println(final.Contains(ctx, "key"))
 }
 ```

--- a/client.go
+++ b/client.go
@@ -1,19 +1,22 @@
 package blobstore
 
-import "io"
+import (
+	"context"
+	"io"
+)
 
 type Client interface {
 	// Return the contents at a given key. Returns an error if the key doesn't
 	// exist.
-	Get(key string) (io.ReadCloser, int64, error)
+	Get(ctx context.Context, key string) (io.ReadCloser, int64, error)
 
 	// Store the contents of the input reader in the blobstore under the given key.
-	Put(key string, blob io.Reader, length int64) error
+	Put(ctx context.Context, key string, blob io.Reader, length int64) error
 
 	// Delete the contents stored at the given key
-	Delete(key string) error
+	Delete(ctx context.Context, key string) error
 
 	// Returns true if the given key is already in the store. May return a
 	// error if the store in unavailable
-	Contains(key string) (bool, error)
+	Contains(ctx context.Context, key string) (bool, error)
 }

--- a/fs.go
+++ b/fs.go
@@ -1,6 +1,7 @@
 package blobstore
 
 import (
+	"context"
 	"crypto"
 	"encoding/binary"
 	"encoding/hex"
@@ -37,7 +38,7 @@ type fsHeader struct {
 
 var fsHeaderEndianness = binary.BigEndian
 
-func (s *fsStore) Put(key string, blob io.Reader, length int64) error {
+func (s *fsStore) Put(ctx context.Context, key string, blob io.Reader, length int64) error {
 	finalPath := s.makePath(key)
 	tempPath := finalPath + "-temp"
 	f, err := os.Create(tempPath)
@@ -75,7 +76,7 @@ func (s *fsStore) Put(key string, blob io.Reader, length int64) error {
 	return os.Rename(tempPath, finalPath)
 }
 
-func (s *fsStore) Get(key string) (io.ReadCloser, int64, error) {
+func (s *fsStore) Get(ctx context.Context, key string) (io.ReadCloser, int64, error) {
 	f, err := os.Open(s.makePath(key))
 	if err != nil {
 		return nil, 0, err
@@ -98,11 +99,11 @@ func (s *fsStore) Get(key string) (io.ReadCloser, int64, error) {
 	return f, hdr.Length, nil
 }
 
-func (s *fsStore) Delete(key string) error {
+func (s *fsStore) Delete(ctx context.Context, key string) error {
 	return os.Remove(s.makePath(key))
 }
 
-func (s *fsStore) Contains(key string) (bool, error) {
+func (s *fsStore) Contains(ctx context.Context, key string) (bool, error) {
 	_, err := os.Lstat(s.makePath(key))
 	switch {
 	case err == nil:

--- a/map.go
+++ b/map.go
@@ -2,6 +2,7 @@ package blobstore
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -20,7 +21,7 @@ func NewMap() *Map {
 	}
 }
 
-func (m *Map) Put(key string, blob io.Reader, length int64) error {
+func (m *Map) Put(ctx context.Context, key string, blob io.Reader, length int64) error {
 	var buf bytes.Buffer
 	_, err := io.CopyN(&buf, blob, length)
 	if err != nil {
@@ -32,14 +33,14 @@ func (m *Map) Put(key string, blob io.Reader, length int64) error {
 	return nil
 }
 
-func (m *Map) Delete(key string) error {
+func (m *Map) Delete(ctx context.Context, key string) error {
 	m.Lock()
 	delete(m.Values, key)
 	m.Unlock()
 	return nil
 }
 
-func (m *Map) Get(key string) (io.ReadCloser, int64, error) {
+func (m *Map) Get(ctx context.Context, key string) (io.ReadCloser, int64, error) {
 	m.Lock()
 	defer m.Unlock()
 	val, ok := m.Values[key]
@@ -49,7 +50,7 @@ func (m *Map) Get(key string) (io.ReadCloser, int64, error) {
 	return ioutil.NopCloser(bytes.NewReader(val)), int64(len(val)), nil
 }
 
-func (m *Map) Contains(key string) (bool, error) {
+func (m *Map) Contains(ctx context.Context, key string) (bool, error) {
 	m.Lock()
 	defer m.Unlock()
 	_, ok := m.Values[key]

--- a/map_test.go
+++ b/map_test.go
@@ -1,15 +1,17 @@
 package blobstore
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"strings"
 )
 
 func ExampleMap_Usage() {
+	ctx := context.TODO()
 	store := NewMap()
-	_ = store.Put("foo", strings.NewReader("bar"), int64(len("bar")))
-	rc, _, _ := store.Get("foo")
+	_ = store.Put(ctx, "foo", strings.NewReader("bar"), int64(len("bar")))
+	rc, _, _ := store.Get(ctx, "foo")
 	b, _ := ioutil.ReadAll(rc)
 	fmt.Println(string(b))
 	// "bar"


### PR DESCRIPTION
Pass in a context as the first arugment to Get, Put, Contains, and
Delete. Nothing checks the status of the context, but I may add that in
a future pull request.

The S3 blobstore correct uses the `WithContext` AWS SDK methods.

The README has been updated with new contextualized API.